### PR TITLE
Future proof | Removing reliance on '-' character

### DIFF
--- a/Private/FindValidSudokuGrid.ps1
+++ b/Private/FindValidSudokuGrid.ps1
@@ -34,7 +34,7 @@ Function FindValidSudokuGrid {
             [int32]$RowToTry = Get-Random -Minimum 0 -Maximum 8
             [int32]$ColToTry = Get-Random -Minimum 0 -Maximum 8
             #Make sure move is valid and is not in use already
-            if ((IsMoveValid -SudokuGrid $Grid -Row ($RowToTry+1) -Col ($ColToTry+1) -Number $NumToTry) -and ($Grid[$RowToTry][$ColToTry] -eq '-')) {
+            if ((IsMoveValid -SudokuGrid $Grid -Row ($RowToTry+1) -Col ($ColToTry+1) -Number $NumToTry) -and ($Grid[$RowToTry][$ColToTry] -match '[^1-9]')) {
                 $Grid[$RowToTry][$ColToTry] = $NumToTry #assign the number to the grid
                 $ReturnGrid[$RowToTry][$ColToTry] = $NumToTry #update the return grid
                 $Grid = DeepCopyArray $ReturnGrid #re-copy the current state of the return grid to the grid

--- a/Private/GetSudokuMove.ps1
+++ b/Private/GetSudokuMove.ps1
@@ -44,7 +44,7 @@ Function GetSudokuMove {
         Catch {
             Write-Error "Row, Column, and Number must be a number between 1-9, '-hint', or '-solve'"
         }
-        if ($OriginalGrid[$Row-1][$Column-1] -ne '-') {
+        if ($OriginalGrid[$Row-1][$Column-1] -match '[1-9]') {
             Write-Error "You cannot modify this number as it is part of the original board."
             continue
         }

--- a/Private/RemoveRandomNumsFromGrid.ps1
+++ b/Private/RemoveRandomNumsFromGrid.ps1
@@ -30,7 +30,7 @@ Function RemoveRandomNumsFromGrid {
         :middleloop for ($j = 0; $j -lt 9; $j++) {
             for ($k = 0; $k -lt 9; $k++) {
                 if ($LocToRemove -eq $Ctr) {
-                    if ($ReturnGrid[$j][$k] -ne '-') {
+                    if ($ReturnGrid[$j][$k] -match '[1-9]') {
                         $ReturnGrid[$j][$k] = '-' #erase the number
                         $RemovedNumbers += 1
                     }

--- a/Public/FindEmptySpot.ps1
+++ b/Public/FindEmptySpot.ps1
@@ -20,7 +20,7 @@ Function FindEmptySpot {
     
     for ($i = 0; $i -lt 9; $i++) {
         for($j = 0; $j -lt 9; $j++) {
-            if ($SudokuGrid[$i][$j] -match '[^1-9]') {
+            if ($SudokuGrid[$i][$j] -eq '-') {
                 return [System.Tuple]::Create(($i+1),($j+1))
             }
         }

--- a/Public/FindEmptySpot.ps1
+++ b/Public/FindEmptySpot.ps1
@@ -20,7 +20,7 @@ Function FindEmptySpot {
     
     for ($i = 0; $i -lt 9; $i++) {
         for($j = 0; $j -lt 9; $j++) {
-            if ($SudokuGrid[$i][$j] -eq '-') {
+            if ($SudokuGrid[$i][$j] -match '[^1-9]') {
                 return [System.Tuple]::Create(($i+1),($j+1))
             }
         }

--- a/Public/IsColumnPlacementValid.ps1
+++ b/Public/IsColumnPlacementValid.ps1
@@ -28,7 +28,7 @@ Function IsColumnPlacementValid {
         [int32]$Number
     )
     ForEach ($Row in $SudokuGrid) {
-        if ($Row[$Column - 1] -eq $Number) {
+        if ([string]$Row[$Column - 1] -eq [string]$Number) {
             return $false
         }
     }

--- a/Public/IsRowPlacementValid.ps1
+++ b/Public/IsRowPlacementValid.ps1
@@ -28,7 +28,7 @@ Function IsRowPlacementValid {
         [int32]$Number
     )
     $SelectedRow = $SudokuGrid[$Row - 1]
-    if ($SelectedRow.Contains($Number)) {
+    if (($SelectedRow.Contains($Number)) -or ($SelectedRow.Contains([string]$Number))) {
         return $false
     }
     else {

--- a/Public/IsSubgridPlacementValid.ps1
+++ b/Public/IsSubgridPlacementValid.ps1
@@ -38,7 +38,7 @@ Function IsSubgridPlacementValid {
     [int32]$SubgridColumnStart = [Math]::Floor(($CalcCol / 3)) * 3
     for ($i = $SubgridRowStart; $i -lt $SubgridRowStart + 3; $i++) {
         for ($j = $SubgridColumnStart; $j -lt $SubgridColumnStart + 3; $j++) {
-            if ($SudokuGrid[($i)][($j)] -eq $Number) {
+            if ([string]$SudokuGrid[($i)][($j)] -eq [string]$Number) {
                 return $false
             }
         }


### PR DESCRIPTION
Made updates to remove places that looked for empty spots by checking if Sudoku grid value was the '-' character.
Instead used regex to check if Sudoku grid value matched/not matched the numbers 1-9.

This will prevent any future issues if the empty spot character is ever changed from '-' to something else.